### PR TITLE
Could not run commands

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -50,7 +50,7 @@ fs.readFile(process.env.HOME + '/.ssh/config', function (err, data) {
       'Name' : name,
       'ShortCut' : '',
       'Custom Command' : 'Yes',
-      'Command' : 'ssh ' + host,
+      'Command' : 'bash -lc "ssh ' + host + '"',
     }
 
     if (section['#Tags']) {


### PR DESCRIPTION
Could not run commands because the default path was not loaded while running commands directly. I use assh in combination with iterm2 and it always told me

/bin/bash: line 0: exec: assh: not found

and interrupted